### PR TITLE
implemented functionality to print version 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,5 @@ pub mod cli {
         pub(crate) pattern: String,
         #[structopt(parse(from_os_str), required_unless = "version")]
         pub path: PathBuf,
-        #[structopt(short = "v", long = "version", help = "print version")]
-        pub version: bool
     }
 }


### PR DESCRIPTION
This PR implements functionality requested in issue #4.

Basically adding the capability for grepru to print the version number using the functionality provided by
clap, which a dependency on which the structop library is based. 
 
